### PR TITLE
Issue 115: store string as scalar by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(pniio
         LANGUAGES CXX C
-        VERSION 1.2.10)
+        VERSION 1.3.0)
 include(CTest)
 
 

--- a/src/pni/io/nexus/xml/attribute_builder.cpp
+++ b/src/pni/io/nexus/xml/attribute_builder.cpp
@@ -40,7 +40,16 @@ void AttributeBuilder::build(const hdf5::node::Node &parent) const
   std::string attribute_name = node().name();
 
   hdf5::datatype::Datatype type = datatype_builder_.build();
-  hdf5::dataspace::Simple space = dataspace_builder_.build();
+  hdf5::dataspace::Dataspace space = hdf5::dataspace::Scalar();
+
+  bool is_string = ((type.get_class() == hdf5::datatype::Class::VARLENGTH)
+		    ||
+		    (type.get_class() == hdf5::datatype::Class::STRING));
+
+  if( (!is_string) || node().get_child_optional("dimensions"))
+  {
+    space = dataspace_builder_.build();
+  }
 
   hdf5::attribute::Attribute attribute = parent.attributes.create(attribute_name,type,space);
 

--- a/src/pni/io/nexus/xml/data_writer.cpp
+++ b/src/pni/io/nexus/xml/data_writer.cpp
@@ -42,6 +42,20 @@ void write_string_data(const std::string &data,const OBJ &object)
 }
 
 template<typename OBJ>
+void extend_simple_scalar(const OBJ &){
+}
+
+void extend_simple_scalar(const hdf5::node::Dataset &object){
+  auto dataspace = object.dataspace();
+  if(dataspace.size() == 0){
+    hdf5::Dimensions chunk = object.creation_list().chunk();
+    if(chunk.size() == 1 && chunk[0] == 1){
+      object.extent(0, 1);
+    }
+  }
+}
+
+template<typename OBJ>
 void write_data(const Node &node,const OBJ &object)
 {
   using namespace pni::core;
@@ -49,6 +63,7 @@ void write_data(const Node &node,const OBJ &object)
   std::string data = node.str_data();
 
   if(data.empty()) return;
+  extend_simple_scalar(object);
 
   switch(type_id)
   {

--- a/src/pni/io/nexus/xml/field_builder.hpp
+++ b/src/pni/io/nexus/xml/field_builder.hpp
@@ -37,6 +37,7 @@ class PNIIO_EXPORT FieldBuilder : public ObjectBuilder
 {
   private:
     hdf5::dataspace::Simple construct_dataspace() const;
+    hdf5::dataspace::Simple construct_empty_dataspace() const;
 
     DataspaceBuilder dataspace_builder_;
     DatatypeBuilder  datatype_builder_;

--- a/test/nexus/xml/field/input.xml
+++ b/test/nexus/xml/field/input.xml
@@ -14,7 +14,7 @@
     	<field type="float128" name="float128_field"></field>
     	<field type="string" name="string_field">hello</field>
     </group>
-    
+
     <group name="multidim_field">
     	<field type="uint16" name="data" units="cps">
     		<dimensions rank="3">
@@ -23,16 +23,19 @@
     			<dim value="2048" index="3"/>
     		</dimensions>
     	</field>
-    
+
         <field type="float32" name="matrix">
         	<dimensions rank="2">
         		<dim value="2" index="0"/>
         		<dim value="2" index="1"/>
         	</dimensions>
         	1 2 3 4
-        </field>    
+        </field>
+
+        <field type="string" name="string_list">
+                <dimensions rank="1">
+                        <dim value="2" index="0"/>
+                </dimensions>
+        </field>
     </group>
-    
-    
-    
 </group>

--- a/test/nexus/xml/field_builder_test.cpp
+++ b/test/nexus/xml/field_builder_test.cpp
@@ -68,39 +68,81 @@ BOOST_AUTO_TEST_CASE(test_scalar_fields)
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/uint8_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::UINT8);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/uint16_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::UINT16);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 1);
+  uint16_t data;
+  dataset.read(data);
+  BOOST_CHECK(data == 23);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/uint32_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::UINT32);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/uint64_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::UINT64);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/int8_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::INT8);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/int16_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::INT16);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/int32_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::INT32);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/int64_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::INT64);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/float32_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::FLOAT32);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/float64_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::FLOAT64);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/float64_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::FLOAT64);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 0);
 
   dataset = hdf5::node::get_node(root_group,"/scalar_fields/string_field");
   BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::STRING);
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SCALAR);
+  BOOST_CHECK(dataspace.size() == 1);
+  std::string sdata;
+  dataset.read(sdata);
+  BOOST_CHECK(sdata == std::string("hello"));
 }
 
 BOOST_AUTO_TEST_CASE(test_multidim_fields)
@@ -108,8 +150,23 @@ BOOST_AUTO_TEST_CASE(test_multidim_fields)
   using namespace pni::io;
   using pni::core::type_id_t;
 
+  dataset = hdf5::node::get_node(root_group,"/multidim_field/matrix");
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::FLOAT32);
+  BOOST_CHECK(dataspace.size() == 4);
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataset.creation_list().layout() == hdf5::property::DatasetLayout::CHUNKED);
+
+  dataset = hdf5::node::get_node(root_group,"/multidim_field/string_list");
+  dataspace = dataset.dataspace();
+  BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::STRING);
+  BOOST_CHECK(dataspace.size() == 2);
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataset.creation_list().layout() == hdf5::property::DatasetLayout::CHUNKED);
+
   dataset = hdf5::node::get_node(root_group,"/multidim_field/data");
   dataspace = dataset.dataspace();
+  BOOST_CHECK(nexus::get_type_id(dataset) == type_id_t::UINT16);
   BOOST_CHECK(dataspace.size() == 0);
   BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
   BOOST_CHECK(dataset.creation_list().layout() == hdf5::property::DatasetLayout::CHUNKED);

--- a/test/nexus/xml/scalar_attribute_builder_test.cpp
+++ b/test/nexus/xml/scalar_attribute_builder_test.cpp
@@ -48,6 +48,9 @@ BOOST_AUTO_TEST_CASE(test_uint8_attribute)
   uint8 data;
   attribute.read(data);
   BOOST_CHECK(data == 12);
+  auto dataspace = attribute.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 1);
 
 }
 
@@ -59,6 +62,9 @@ BOOST_AUTO_TEST_CASE(test_int32_attribute)
   int32 data;
   attribute.read(data);
   BOOST_CHECK(data == -12);
+  auto dataspace = attribute.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SIMPLE);
+  BOOST_CHECK(dataspace.size() == 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_string_attribute)
@@ -69,6 +75,8 @@ BOOST_AUTO_TEST_CASE(test_string_attribute)
   std::string data;
   attribute.read(data);
   BOOST_CHECK(data == "hello");
+  auto dataspace = attribute.dataspace();
+  BOOST_CHECK(dataspace.type() == hdf5::dataspace::Type::SCALAR);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
It resolves #115 by  storing string as scalar by default in xml_to_nexus writer in they do not have `<dimensions>` tag defined
It also resolves #31 by creating a field without values with its zero size.