### PR TITLE
Issue 148: ensure HDF5_LIBRARY_DIRS is defined

### DIFF
--- a/src/pni/CMakeLists.txt
+++ b/src/pni/CMakeLists.txt
@@ -101,6 +101,14 @@ target_link_libraries(pninexus
 target_compile_definitions(pninexus PUBLIC BOOST_ALL_DYN_LINK)
 target_compile_definitions(pninexus PRIVATE DLL_BUILD) 
 
+if ((NOT DEFINED HDF5_LIBRARY_DIRS) OR
+    (NOT HDF5_LIBRARY_DIRS) OR
+    ("${HDF5_LIBRARY_DIRS}" STREQUAL ""))
+  list(GET HDF5_LIBRARIES 0 TEMP_HDF5_LIB)
+  get_filename_component(HDF5_LIBRARY_DIRS ${TEMP_HDF5_LIB} DIRECTORY)
+  unset(TEMP_HDF5_LIB)
+endif()
+
 # ============================================================================
 # install the library binaries and targets 
 # ============================================================================

--- a/src/pni/pninexus.pc.cmake
+++ b/src/pni/pninexus.pc.cmake
@@ -4,8 +4,9 @@ includedir = ${prefix}/include
 libdir = ${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: @CMAKE_PROJECT_NAME@
-Description: PNI IO library
+Description: PNI NeXus library
 Version: @LIBRARY_VERSION@
 Cflags: -I${includedir} -I@HDF5_INCLUDE_DIRS@
 Requires: h5cpp
-Libs: -L${libdir} -L@HDF5_LIBRARY_DIRS@ -lpninexus -lhdf5 -lz -lboost_filesystem
+Libs: -L${libdir} -lpninexus
+Libs.private:  -L@HDF5_LIBRARY_DIRS@ -lhdf5 -lhdf5_hl -lz -lboost_filesystem


### PR DESCRIPTION
It resolves #148 by ensuring that that HDF5_LIBRARY_DIRS is defined and cleaning the pninexus.pc file