### PR TITLE
Issue 179: use libh5cpp0.5.0-dev libh5cpp0.5.0 in tests

### DIFF
--- a/.ci/debian10/Dockerfile
+++ b/.ci/debian10/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get -qq -y dist-upgrade
 
 RUN apt-get -qq update && apt-get -qq -y install cmake ninja-build python3-pip g++ doxygen python3-sphinx git libboost-all-dev gfortran graphviz libcppunit-dev texlive doxygen pkg-config texlive-latex-extra texlive-latex-recommended texlive-pictures python3-pygments libhdf5-dev libgtest-dev lsb-release python3-breathe texlive-pictures python3-sphinx-rtd-theme libjs-mathjax fonts-mathjax fonts-mathjax-extras ghostscript
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install jinja2==3.0.3
@@ -26,11 +26,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src

--- a/.ci/debian11/Dockerfile
+++ b/.ci/debian11/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get -qq -y dist-upgrade
 
 RUN apt-get -qq update && apt-get -qq -y install cmake ninja-build python3-pip g++ doxygen python3-sphinx git libboost-all-dev gfortran graphviz libcppunit-dev texlive doxygen pkg-config texlive-latex-extra texlive-latex-recommended texlive-pictures python3-pygments libhdf5-dev libgtest-dev lsb-release python3-breathe texlive-pictures python3-sphinx-rtd-theme libjs-mathjax fonts-mathjax fonts-mathjax-extras ghostscript
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install conan
@@ -26,11 +26,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src

--- a/.ci/debian9/Dockerfile
+++ b/.ci/debian9/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && apt-get -qq -y install cmake ninja-build python3-pip g
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
 RUN apt-get -qq update && apt-get -t stretch-backports-sloppy -y install libarchive13
 RUN apt-get -qq update && apt-get -t stretch-backports -y install cmake
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install jinja2==2.11.3
@@ -31,11 +31,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DCMAKE_CXX_STANDARD=11 -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DCMAKE_CXX_STANDARD=11 -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src

--- a/.ci/ubuntu18.04/Dockerfile
+++ b/.ci/ubuntu18.04/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq d
 RUN /bin/bash -c 'echo "Europe/Berlin" > /etc/timezone'
 RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq -y install cmake ninja-build python3-pip g++ doxygen python3-sphinx git libboost-all-dev gfortran graphviz libcppunit-dev texlive doxygen pkg-config texlive-latex-extra texlive-latex-recommended texlive-pictures python3-pygments libhdf5-dev libgtest-dev lsb-release python3-breathe texlive-pictures python3-sphinx-rtd-theme libjs-mathjax fonts-mathjax fonts-mathjax-extras ghostscript
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install jinja2==3.0.3
@@ -27,11 +27,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src

--- a/.ci/ubuntu20.04/Dockerfile
+++ b/.ci/ubuntu20.04/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq d
 RUN /bin/bash -c 'echo "Europe/Berlin" > /etc/timezone'
 RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq -y install cmake ninja-build python3-pip g++ doxygen python3-sphinx git libboost-all-dev gfortran graphviz libcppunit-dev texlive doxygen pkg-config texlive-latex-extra texlive-latex-recommended texlive-pictures python3-pygments libhdf5-dev libgtest-dev lsb-release python3-breathe texlive-pictures python3-sphinx-rtd-theme libjs-mathjax fonts-mathjax fonts-mathjax-extras ghostscript
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install jinja2==3.0.3
@@ -26,11 +26,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src

--- a/.ci/ubuntu22.04/Dockerfile
+++ b/.ci/ubuntu22.04/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq d
 RUN /bin/bash -c 'echo "Europe/Berlin" > /etc/timezone'
 RUN apt-get -qq update && export DEBIAN_FRONTEND=noninteractive && apt-get -qq -y install cmake ninja-build python3-pip g++ doxygen python3-sphinx git libboost-all-dev gfortran graphviz graphviz libcppunit-dev texlive doxygen pkg-config texlive-latex-extra texlive-latex-recommended texlive-pictures python3-pygments libhdf5-dev libgtest-dev lsb-release python3-breathe texlive-pictures python3-sphinx-rtd-theme libjs-mathjax fonts-mathjax fonts-mathjax-extras ghostscript
 RUN apt-get -qq update && apt-get -qq -y install libhdf5-dev
-# RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.4.1-dev libh5cpp0.4.1
+RUN apt-get -qq update && apt-get -qq -y install libh5cpp0.5.0-dev libh5cpp0.5.0
 
 RUN apt-get clean
 RUN pip3 install conan
@@ -25,11 +25,11 @@ RUN conan remote add conan-community https://api.bintray.com/conan/conan-communi
 RUN conan remote add conan-center https://conan.bintray.com
 RUN conan remote add conan-transit https://conan-transit.bintray.com
 
-# install latest h5cpp
-RUN mkdir -p /opt/h5cpp
-RUN mkdir -p /h5cpp-src
-RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
-RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
+# # install latest h5cpp
+# RUN mkdir -p /opt/h5cpp
+# RUN mkdir -p /h5cpp-src
+# RUN cd /h5cpp-src && git clone https://github.com/ess-dmsc/h5cpp && mkdir build
+# RUN cd /h5cpp-src/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/h5cpp -DCMAKE_BUILD_TYPE=Release -DH5CPP_CONAN=DISABLE -DH5CPP_DISABLE_TESTS=True  ../h5cpp && make install -j4
 
 RUN conan user
 RUN mkdir /src


### PR DESCRIPTION
It resolves #179 by using  libh5cpp0.5.0-dev libh5cpp0.5.0 in tests