### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/conan/profiles/vs2019
+++ b/.github/workflows/conan/profiles/vs2019
@@ -1,0 +1,10 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=msvc
+compiler.version=192
+compiler.runtime=dynamic
+os=Windows
+
+[conf]
+tools.env.virtualenv:powershell=True

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,7 +203,7 @@ jobs:
       - name: build h5cpp
         run: |
           mkdir h5cpp-src && cd h5cpp-src &&  git clone https://github.com/ess-dmsc/h5cpp && mkdir h5cpp-build
-          CONAN_ARGS=" --profile h5cpp/.github/workflows/conan/profiles/vs2022 \
+          CONAN_ARGS=" --profile ../.github/workflows/conan/profiles/vs2019 \
             -o with_boost=False \
             -o shared=${PNINEXUS_SHARED} \
             -o install_prefix=D:/a/libpninexus/libpninexus/h5cpp-src/h5cppbin \
@@ -219,7 +219,7 @@ jobs:
           cd ../../
       - name: build pninexus
         run: |
-          CONAN_ARGS=" --profile h5cpp-src/h5cpp/.github/workflows/conan/profiles/vs2022 \
+          CONAN_ARGS=" --profile .github/workflows/conan/profiles/vs2019 \
             -o with_boost=True \
             -o shared=${PNINEXUS_SHARED} \
             -o install_prefix=D:/a/libpninexus/libpninexus/h5cpp-src/h5cppbin \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,7 +203,7 @@ jobs:
       - name: build h5cpp
         run: |
           mkdir h5cpp-src && cd h5cpp-src &&  git clone https://github.com/ess-dmsc/h5cpp && mkdir h5cpp-build
-          CONAN_ARGS=" --profile ../.github/workflows/conan/profiles/vs2019 \
+          CONAN_ARGS=" --profile h5cpp/.github/workflows/conan/profiles/vs2022 \
             -o with_boost=False \
             -o shared=${PNINEXUS_SHARED} \
             -o install_prefix=D:/a/libpninexus/libpninexus/h5cpp-src/h5cppbin \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,68 @@ jobs:
           cd build
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
           make check CTEST_OUTPUT_ON_FAILURE=TRUE  -j4
+  windows-2019:
+    strategy:
+      matrix:
+        shared: [
+          "shared",
+          # "static"  # not supported yet
+        ]
+    runs-on: windows-2019
+    steps:
+      - name: check cmake
+        run: |
+            cmake --version
+      - uses: actions/checkout@v2
+      - name: Add MSVC to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Set environment variables
+        run: |
+            bash .github/workflows/set_env_vars.sh \
+              ${{ matrix.shared }} \
+              "serial"
+      - name: Install and configure conan
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade conan==2.0.2
+      - name: build h5cpp
+        run: |
+          mkdir h5cpp-src && cd h5cpp-src &&  git clone https://github.com/ess-dmsc/h5cpp && mkdir h5cpp-build
+          CONAN_ARGS=" --profile ../.github/workflows/conan/profiles/vs2019 \
+            -o with_boost=False \
+            -o shared=${PNINEXUS_SHARED} \
+            -o install_prefix=D:/a/libpninexus/libpninexus/h5cpp-src/h5cppbin \
+            -o *:shared=${PNINEXUS_SHARED}"
+          conan profile detect
+          conan remove -c zlib/*
+          # conan remove -c boost/*
+          # conan remove -c b2/*
+          conan install h5cpp ${CONAN_ARGS} --output-folder h5cpp-build --build missing --update
+          conan build h5cpp ${CONAN_ARGS} --output-folder h5cpp-build
+          cd  h5cpp-build
+          cmake --install . --prefix "../h5cppbin/"
+          cd ../../
+      - name: build pninexus
+        run: |
+          CONAN_ARGS=" --profile .github/workflows/conan/profiles/vs2019 \
+            -o with_boost=True \
+            -o shared=${PNINEXUS_SHARED} \
+            -o install_prefix=D:/a/libpninexus/libpninexus/h5cpp-src/h5cppbin \
+            -o *:shared=${PNINEXUS_SHARED}"
+          conan install . ${CONAN_ARGS}  --output-folder build   --build missing  --update
+          conan build . ${CONAN_ARGS}  --output-folder build
+      - name: run tests
+        run: |
+          cd build
+          copy ..\h5cpp-src\h5cppbin\bin\h5cpp.dll .\bin\
+          # .\conanbuild.bat
+          # .\conanrun.bat
+          .\conanbuildenv-release-x86_64.ps1
+          .\conanrunenv-release-x86_64.ps1
+          cmake --build . --verbose --target check --config RELEASE
+        shell: pwsh
   windows-2022:
+    if: false
     strategy:
       matrix:
         shared: [

--- a/conanfile.py
+++ b/conanfile.py
@@ -46,7 +46,7 @@ class PNINeXusConan(ConanFile):
 
         if self.options.get_safe("with_boost", False):
             if self.settings.os == "Windows":
-                self.requires("boost/1.81.0")
+                self.requires("boost/1.85.0")
             elif self.settings.os == "Macos":
                 self.requires("boost/1.81.0")
             else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,10 +25,10 @@ class PNINeXusConan(ConanFile):
     }
 
     def build_requirements(self):
-	if self.settings.os == "Windows":
-	    self.tool_requires("b2/4.10.1")
         self.build_requires("ninja/1.10.2")
         self.build_requires("zlib/1.2.13")
+        if self.settings.os == "Windows":
+           self.tool_requires("b2/4.10.1")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,8 @@ class PNINeXusConan(ConanFile):
     }
 
     def build_requirements(self):
+	if self.settings.os == "Windows":
+	    self.tool_requires("b2/4.10.1")
         self.build_requires("ninja/1.10.2")
         self.build_requires("zlib/1.2.13")
 
@@ -46,7 +48,7 @@ class PNINeXusConan(ConanFile):
 
         if self.options.get_safe("with_boost", False):
             if self.settings.os == "Windows":
-                self.requires("boost/1.85.0")
+                self.requires("boost/1.81.0")
             elif self.settings.os == "Macos":
                 self.requires("boost/1.81.0")
             else:


### PR DESCRIPTION
Because boost doesn't compile with VS2022 in conan, the Windows-2022 job is temporarily disabled. Windows-2019 is enabled.
A conan profile VS2019 is created for Windows-2019 job in libpninexus project.