### PR TITLE
fix Warning: Failed to remove 'http.https://github.com/.extraheader' from the git config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,9 @@ jobs:
           MESSAGE: "Build: ({sha}) {msg}"
 
       - name: Stop the docker
-        run: docker container stop build
+        run: |
+             docker exec  --user root build  /bin/bash -c "chown -R 1001 /home/p00user/src "
+             docker container stop build
 
   conan:
     strategy:


### PR DESCRIPTION
It fixes Warning: Failed to remove 'http.https://github.com/.extraheader' from the git config after building documentation in CIs